### PR TITLE
Remove explicit dynamic linking of this library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ import PackageDescription
 let package = Package(
     name: "SipHash",
     products: [
-        .library(name: "SipHash", type: .dynamic, targets: ["SipHash"])
+        .library(name: "SipHash", targets: ["SipHash"])
     ],
     dependencies: [],
     targets: [


### PR DESCRIPTION
I think explicitly requiring the library to build a .dylib is not necessary. The user should decide this depending on their needs.